### PR TITLE
Change fix for double appearance forwarding

### DIFF
--- a/IAMenuController/IAMenuController.m
+++ b/IAMenuController/IAMenuController.m
@@ -55,13 +55,11 @@ NSString *const IAMenuDidCloseNotification = @"IAMenuDidCloseNotification";
     
     [self removeTapInterceptView];
     [oldContent willMoveToParentViewController:nil];
-    [oldContent viewWillDisappear:YES];
-    
+
     [UIView animateWithDuration:0.2 delay:0.0 options:0 animations:^{
         self.contentView.frame = [self contentViewFrameForStaging];
     } completion:^(BOOL finished) {
         [oldContent.view removeFromSuperview];
-        [oldContent viewDidDisappear:YES];
         [oldContent removeFromParentViewController];
         
         [self addChildViewController:_contentViewController];
@@ -73,7 +71,6 @@ NSString *const IAMenuDidCloseNotification = @"IAMenuDidCloseNotification";
         [UIView animateWithDuration:0.22 delay:0.1 options:0 animations:^{
             self.contentView.frame = [self contentViewFrameForClosedMenu];
         } completion:^(BOOL finished) {
-            [_contentViewController viewDidAppear:YES];
             self.menuIsVisible = NO;
         }];
     }];


### PR DESCRIPTION
Unfortunately a recently discovered side-effect of overriding
shouldAutomaticallyForwardAppearanceMethods on IAMenuController is that
child view controllers stop receiving appearance methods when modal
controllers are dismissed on top of them. Other appearance methods seem
to be getting forwarded fine, but as a workaround for this, since the
podspec for this requires iOS6 and we can expect automatic appearance
forwarding to always be enabled, we should be able to just rely on it
when subviews are added and remove the manual viewWillDisappear/
viewDidDisappear/viewDidAppear calls being made.
