### PR TITLE
Change fix for double appearance forwarding

### DIFF
--- a/IAMenuController/IAMenuController.m
+++ b/IAMenuController/IAMenuController.m
@@ -239,9 +239,7 @@ NSString *const IAMenuDidCloseNotification = @"IAMenuDidCloseNotification";
     if (pan.state == UIGestureRecognizerStateBegan)
     {
         if (translation.x < minimumX)
-            return;
-        
-        [self.menuViewController viewWillAppear:YES];
+            return;        
     }
     else if (pan.state == UIGestureRecognizerStateChanged)
     {

--- a/IAMenuControllerSample/ListViewController.m
+++ b/IAMenuControllerSample/ListViewController.m
@@ -57,4 +57,20 @@
     self.menuController.contentViewController = mvc;
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+}
+
 @end

--- a/IAMenuControllerSample/MainViewController.m
+++ b/IAMenuControllerSample/MainViewController.m
@@ -11,8 +11,27 @@
 
 @implementation MainViewController
 
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    UIBarButtonItem *toggleMenuButton = [[UIBarButtonItem alloc] initWithTitle:@"Menu" style:UIBarButtonItemStylePlain target:self.menuController action:@selector(toggleMenu)];
+    self.navigationItem.leftBarButtonItem = toggleMenuButton;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+}
+
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
 }
 
 @end


### PR DESCRIPTION
Unfortunately a recently discovered side-effect of overriding
shouldAutomaticallyForwardAppearanceMethods on IAMenuController is that
child view controllers stop receiving appearance methods when modal
controllers are dismissed on top of them. 

Other appearance methods seem to be getting forwarded fine, but as a workaround 
for this, since the podspec for this requires iOS6 and we can expect automatic appearance
forwarding to always be enabled, we should be able to just rely on it when subviews are added/removed instead of the manual viewWillDisappear/viewDidDisappear/viewDidAppear 
calls being made.
